### PR TITLE
Migrate to Factory

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -26,11 +26,11 @@ config:
 build:
   correctness:
     build:
-      image: vaticle-ubuntu-20.04
+      image: vaticle-ubuntu-22.04
       command: |
         bazel build //...
     test-benchmark:
-      image: vaticle-ubuntu-20.04
-      machine: 4-core-8-gb
+      image: vaticle-ubuntu-22.04
+      machine: 4-core-16-gb
       command: |
         bazel test //benchmark/... --test_output=streamed

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -25,5 +25,5 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "a8b3b714a5e0562d41f4c05ca8f266d48b7d0fd3", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "4464b506ca469f37d3b696fb2f1eda34061cdaa1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )


### PR DESCRIPTION
## What is the goal of this PR?

We've migrated our continuous integration for this repo to Vaticle Factory from Grabl.

## What are the changes implemented in this PR?

We've updated:
- dependencies.
- machine definitions from ubuntu 20.04 to 22.04.
